### PR TITLE
【確認待ち】has-${色名}-border-color クラスを追加

### DIFF
--- a/src/VkColorPaletteManager.php
+++ b/src/VkColorPaletteManager.php
@@ -155,6 +155,7 @@ class VkColorPaletteManager {
 				// .has- だけだと負けるので :root は迂闊に消さないように注意
 				$dynamic_css .= ':root .has-' . $color['slug'] . '-color { color:var(--' . $color['slug'] . '); }';
 				$dynamic_css .= ':root .has-' . $color['slug'] . '-background-color { background-color:var(--' . $color['slug'] . '); }';
+				$dynamic_css .= ':root .has-' . $color['slug'] . '-border-color { border-color:var(--' . $color['slug'] . '); }';
 			}
 		}
 


### PR DESCRIPTION
has-${色名}-border-color クラスを追加しました
コアでは5.9からの機能ですが5.8で出力されていても特に問題はないと判断し条件はつけていないです

`has-vk-color-primary-border-color`などを追加 CSS クラスなどに追加してカラーが当たるか確認お願いします
