### PR TITLE
【2人目確認待ち】カラーパレットのCSS変数をコアの変数名--wp--preset--color--$slugに合わせる

### DIFF
--- a/src/VkColorPaletteManager.php
+++ b/src/VkColorPaletteManager.php
@@ -151,9 +151,12 @@ class VkColorPaletteManager {
 		foreach ( $colors as $key => $color ) {
 			if ( ! empty( $color['color'] ) ) {
 				// 色はこのクラスでだけの利用なら直接指定でも良いが、他のクラス名で応用できるように一旦css変数に格納している.
-				$dynamic_css .= ':root{ --' . $color['slug'] . ':' . $color['color'] . '}';
-				// 6.1より画像ブロックなどでインラインでstyle="border-top-color:var(--wp--preset--color--$slug);"が入るため変数名をコアに合わせる
+				// 6.1より画像ブロックなどでインラインでstyle="border-top-color:var(--wp--preset--color--$slug);"が入るため変数名をコアに合わせる.
 				$dynamic_css .= ':root{ --wp--preset--color--' . $color['slug'] . ':' . $color['color'] . '}';
+
+				// 古いCSS変数名のフォールバック.
+				$dynamic_css .= '/* --' . $color['slug'] . ' is deprecated. */';
+				$dynamic_css .= ':root{ --' . $color['slug'] . ': var(--wp--preset--color--' . $color['slug'] . ');}';
 				// .has- だけだと負けるので :root は迂闊に消さないように注意
 				$dynamic_css .= ':root .has-' . $color['slug'] . '-color { color:var(--wp--preset--color--' . $color['slug'] . '); }';
 				$dynamic_css .= ':root .has-' . $color['slug'] . '-background-color { background-color:var(--wp--preset--color--' . $color['slug'] . '); }';

--- a/src/VkColorPaletteManager.php
+++ b/src/VkColorPaletteManager.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-color-palette-manager
  * @license GPL-2.0+
  *
- * @version 0.3.0
+ * @version 0.4.0
  */
 
 namespace VektorInc\VK_Color_Palette_Manager;

--- a/src/VkColorPaletteManager.php
+++ b/src/VkColorPaletteManager.php
@@ -152,10 +152,12 @@ class VkColorPaletteManager {
 			if ( ! empty( $color['color'] ) ) {
 				// 色はこのクラスでだけの利用なら直接指定でも良いが、他のクラス名で応用できるように一旦css変数に格納している.
 				$dynamic_css .= ':root{ --' . $color['slug'] . ':' . $color['color'] . '}';
+				// 6.1より画像ブロックなどでインラインでstyle="border-top-color:var(--wp--preset--color--$slug);"が入るため変数名をコアに合わせる
+				$dynamic_css .= ':root{ --wp--preset--color--' . $color['slug'] . ':' . $color['color'] . '}';
 				// .has- だけだと負けるので :root は迂闊に消さないように注意
-				$dynamic_css .= ':root .has-' . $color['slug'] . '-color { color:var(--' . $color['slug'] . '); }';
-				$dynamic_css .= ':root .has-' . $color['slug'] . '-background-color { background-color:var(--' . $color['slug'] . '); }';
-				$dynamic_css .= ':root .has-' . $color['slug'] . '-border-color { border-color:var(--' . $color['slug'] . '); }';
+				$dynamic_css .= ':root .has-' . $color['slug'] . '-color { color:var(--wp--preset--color--' . $color['slug'] . '); }';
+				$dynamic_css .= ':root .has-' . $color['slug'] . '-background-color { background-color:var(--wp--preset--color--' . $color['slug'] . '); }';
+				$dynamic_css .= ':root .has-' . $color['slug'] . '-border-color { border-color:var(--wp--preset--color--' . $color['slug'] . '); }';
 			}
 		}
 


### PR DESCRIPTION
[#1446](https://github.com/vektor-inc/vk-blocks-pro/issues/1446)
カラーパレットのCSS変数はコアの変数名--wp--preset--color--$slugに合わせないと色が当たらないことがあるので`:root{ --wp--preset--color--' . $color['slug'] . ':' . $color['color'] . '}`を追加しました

### 環境
WordPress 6.1
テーマ:TT2などのブロックテーマ
カスタマイザーでカスタムカラーを設定し画像ブロックで上下左右のboderの色を変えたときに色が変わるか確認お願いします

### 検討.相談
すぐにはリリースしないとしても
--vk-color-custom-1などのCSS変数は廃止して--wp--preset--color--$slugに統一し--vk-color-primaryや--vk-color-primary-darkなどはテーマ側で対応した方が良いかもと思うのですがどうでしょうか？

そうすれば154行目の`$dynamic_css .= ':root{ --' . $color['slug'] . ':' . $color['color'] . '}';`が不要になります